### PR TITLE
Enable using PostgreSQL connection strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This code repository and the resources within it are meant to assist anyone who is attempting to determine the readiness of their RDS/Aurora PostgreSQL cluster to be used with Blue/Green Deployments. Currently, Blue/Green Deployments has specific requirements within each PostgreSQL database in a given cluster that dictate whether Blue/Green Deployments can be used. The included BASH and SQL scripts can be used to determine readiness prior to attempting the deployment of Blue/Green Deployments.
+This code repository and the resources within it are meant to assist anyone attempting to determine the readiness of an RDS/Aurora PostgreSQL cluster to be used with Blue/Green Deployments. Currently, Blue/Green Deployments has specific requirements for each PostgreSQL database in a given cluster that dictate whether Blue/Green Deployments can be used. The included BASH and SQL scripts can be used to determine readiness prior to attempting the deployment of Blue/Green Deployments.
 
 ## Blue/Green Deployments Readiness Runbook (PDF Document)
 
@@ -10,11 +10,11 @@ This PDF document contains information on how to use all of the resources in thi
 
 ## Blue/Green Deployments Readiness Script (BASH)
 
-This BASH script automates the contents of the PDF file included in this repository, and prints the output into a text format that is consistent and easy to read. In addition to listing identified problems that will prevent the sucessful usage of Blue/Green Deployments, this BASH script will propose SQL commands to add primary keys and/or change the tables REPLICA IDENTITY setting. Always double check with DBAs/database developers before making schema change (especially in production environments!)
+This BASH script automates the contents of the PDF file included in this repository, and prints the output into a text format that is consistent and easy to read. In addition to listing identified problems that will prevent the sucessful usage of Blue/Green Deployments, this BASH script will propose SQL commands to add primary keys and/or change the tables REPLICA IDENTITY setting. Always double check with DBAs/database developers before making schema changes (especially in production environments!)
 
 ## SQL Scripts
 
-The SQL files are more user-friendly versions of those that drive the included BASH script (also included). These files can be used at an ad-hoc basis for detecting cases within a particular database that would prevent it's usage with Blue/Green Deployments.
+The SQL files are more user-friendly versions of those that drive the included BASH script. These files can be used on an ad-hoc basis to detect cases within a particular database that would prevent its usage with Blue/Green Deployments.
 
 ## Security
 
@@ -23,4 +23,3 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This library is licensed under the MIT-0 License. See the LICENSE file.
-

--- a/bash-script/BlueGreen-precheck-v1.8.sh
+++ b/bash-script/BlueGreen-precheck-v1.8.sh
@@ -29,25 +29,31 @@ NO_LOG=0
 DB_ENDPOINT_FILE=""
 DB_ENDPOINT_USER=""
 DB_ENDPOINT_PASS=""
+DB_CONNECTION_STRING=""
 
 # Help message
 function usage() {
-  printf "Usage: %s [-h host] [-p port] [-U user] [-P password] [-l log_prefix] [--no-log] [--endpoints-file file] [--file-user user] [--file-password password]\n" "$0"
-  printf "  -h, --host          Database host (default: localhost)\n"
-  printf "  -p, --port          Database port (default: 5432)\n"
-  printf "  -U, --user          Database user (default: postgres)\n"
-  printf "  -P, --password      Database password\n"
-  printf "  -l, --log           Log file prefix (logs to a timestamped file)\n"
-  printf "  --no-log            Do not log output\n"
-  printf "  --endpoints-file    Path to file containing a list of host:dbname pairs\n"
-  printf "  --file-user         Database user for the endpoints in the file\n"
-  printf "  --file-password     Database password for the endpoints in the file\n"
+  printf "Usage: %s [-c connection string] [-h host] [-p port] [-U user] [-P password] [-l log_prefix] [--no-log] [--endpoints-file file] [--file-user user] [--file-password password]\n" "$0"
+  printf "  -c, --connection-string   Database connection string\n"
+  printf "  -h, --host                Database host (default: localhost)\n"
+  printf "  -p, --port                Database port (default: 5432)\n"
+  printf "  -U, --user                Database user (default: postgres)\n"
+  printf "  -P, --password            Database password\n"
+  printf "  -l, --log                 Log file prefix (logs to a timestamped file)\n"
+  printf "  --no-log                  Do not log output\n"
+  printf "  --endpoints-file          Path to file containing a list of host:dbname pairs\n"
+  printf "  --file-user               Database user for the endpoints in the file\n"
+  printf "  --file-password           Database password for the endpoints in the file\n"
   exit 1
 }
 
 # Parse input flags
 while [[ $# -gt 0 ]]; do
   case $1 in
+    -c|--connection-string)
+      DB_CONNECTION_STRING="$2"
+      shift 2
+      ;;
     -h|--host)
       DB_HOST="$2"
       shift 2
@@ -100,11 +106,16 @@ fi
 function exec_query() {
   local query="$1"
   local result=""
-  if [[ -z $DB_PASS ]]; then
-    result=$(psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME -t -c "$query")
+  if [[ -z $DB_CONNECTION_STRING ]]; then
+    if [[ -z $DB_PASS ]]; then
+      result=$(psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME -t -c "$query")
+    else
+      result=$(PGPASSWORD=$DB_PASS psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME -t -c "$query")
+    fi
   else
-    result=$(PGPASSWORD=$DB_PASS psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME -t -c "$query")
+    result=$(psql $DB_CONNECTION_STRING -t -c "$query")
   fi
+
   if [[ $NO_LOG -eq 0 ]]; then
     printf "%s\n" "$result" >> "$LOG_FILE"
   else
@@ -115,7 +126,11 @@ function exec_query() {
 
 # Function to get a list of all databases accessible by the user, ignoring specific databases
 function get_databases() {
-  psql -h $DB_HOST -p $DB_PORT -U $DB_USER -t -c "SELECT datname FROM pg_database WHERE datistemplate = false AND datname NOT IN ('rdsadmin', 'template0', 'template1');" -A
+  if [[ -z $DB_CONNECTION_STRING ]]; then
+    psql -h $DB_HOST -p $DB_PORT -U $DB_USER -t -c "SELECT datname FROM pg_database WHERE datistemplate = false AND datname NOT IN ('rdsadmin', 'template0', 'template1');" -A
+  else
+    echo $DB_CONNECTION_STRING | cut -d'/' -f4
+  fi
 }
 
 # Main function to iterate over all databases and propose fixes or raise warnings
@@ -167,15 +182,16 @@ function check_all_databases() {
 
     # Check for presence of pg_largeobject
     printf "============================================================\n"
-    printf "Checking for incompatable pg_largeobjects"
+    printf "Checking for incompatible pg_largeobjects"
     printf "\n ... ... \n"
     check_pg_largeobject="SELECT EXISTS (SELECT 1 FROM pg_largeobject);"
     has_pg_largeobject=$(exec_query "$check_pg_largeobject" | tr -d '[:space:]')
     if [[ $has_pg_largeobject == "t" ]]; then
       printf "\nWARNING: The database %s contains pg_largeobjects, which cannot be replicated.\n" "$db"
       printf "============================================================\n"
-      issues_found=1 ; else
-      printf "No incompatable pg_largeobjects found\n"
+      issues_found=1
+    else
+      printf "No incompatible pg_largeobjects found\n"
       printf "============================================================\n"
     fi
 
@@ -186,36 +202,38 @@ function check_all_databases() {
     check_foreign_tables="SELECT EXISTS (SELECT * FROM information_schema.foreign_tables);"
     has_foreign_tables=$(exec_query "$check_foreign_tables" | tr -d '[:space:]')
     if [[ $has_foreign_tables == "t" ]]; then
-     printf "\nWARNING: The database %s contains foreign tables, which cannot be replicated.\n" "$db"
-     printf "===============================================================================================\n"
-      issues_found=1; else
-    printf "No foreign tables exist on database %s\n"
-    printf "===============================================================================================\n"
+      printf "\nWARNING: The database %s contains foreign tables, which cannot be replicated.\n" "$db"
+      printf "===============================================================================================\n"
+      issues_found=1
+    else
+      printf "No foreign tables exist on database %s\n" "$db"
+      printf "===============================================================================================\n"
 
     fi
   done
 
   # Check for logical replication slots across all databases
-    printf "\n======================================================================================================================================\n"
-    printf "Checking cluster-wide for logical replication slots: $DB_HOST\n" "$db"
-    printf "======================================================================================================================================\n"
+  printf "\n======================================================================================================================================\n"
+  printf "Checking cluster-wide for logical replication slots: %s\n" "$DB_HOST"
+  printf "======================================================================================================================================\n"
   check_logical_slots="SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_type = 'logical');"
   has_logical_slots=$(exec_query "$check_logical_slots" | tr -d '[:space:]')
   if [[ $has_logical_slots == "t" ]]; then
     printf "\nWARNING: Logical replication slots exist in the cluster.\n"
-    issues_found=1; else
+    issues_found=1
+  else
     printf "\n No logical replication slots found cluster-wide"
   fi
 
   # Output readiness message
   if [[ $issues_found -eq 1 ]]; then
     printf "\n==================================================================================================================================\n"
-    printf "Cluster $DB_HOST is NOT READY for usage with Blue/Green Deployments\n"
+    printf "Cluster %s is NOT READY for usage with Blue/Green Deployments\n" "$DB_HOST"
     printf "Please check the script output, fix any issues listed, and try again.\n"
     printf "==================================================================================================================================\n"
   else
     printf "\n===========================================================================================================\n"
-    printf "Cluster $DB_HOST is READY for usage with Blue/Green Deployments\n"
+    printf "Cluster %s is READY for usage with Blue/Green Deployments\n" "$DB_HOST"
     printf "============================================================================================================\n"
   fi
 }

--- a/bash-script/BlueGreen-precheck-v1.8.sh
+++ b/bash-script/BlueGreen-precheck-v1.8.sh
@@ -104,7 +104,8 @@ if [[ -z $DB_CONNECTION_STRING ]]; then
   fi
 else
   if [[ -z $DB_HOST ]]; then
-    DB_HOST=$(printf "$DB_CONNECTION_STRING" | cut -d'@' -f2 | cut -d':' -f1)
+    # DB_HOST=$(printf "$DB_CONNECTION_STRING" | cut -d'@' -f2 | cut -d':' -f1)
+    DB_HOST=$(printf "$DB_CONNECTION_STRING" | awk -F'@' '{print $2}' | awk -F':' '{print $1}')
   fi
 fi
 
@@ -141,7 +142,8 @@ function get_databases() {
   if [[ -z $DB_CONNECTION_STRING ]]; then
     psql -h $DB_HOST -p $DB_PORT -U $DB_USER -t -c "SELECT datname FROM pg_database WHERE datistemplate = false AND datname NOT IN ('rdsadmin', 'template0', 'template1');" -A
   else
-    printf "$DB_CONNECTION_STRING" | cut -d'/' -f4
+    # printf "$DB_CONNECTION_STRING" | cut -d'/' -f4
+    printf "$DB_CONNECTION_STRING" | awk -F'/' '{print $4}'
   fi
 }
 


### PR DESCRIPTION
This adds an argument for setting the DB_CONNECTION_STRING variable to enable using a PostgreSQL connection string with the bash script.

The `get_databases` function was changed to use the connection string's single database name when one is defined. Likewise, the `exec_query` function will use the connection string if it's defined.

I also added a missing argument to the `printf` statement used when no foreign tables exist on a database, and reformatted some of the if-then-else statements to be consistent with other uses in the file and make them easier to read.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.