### PR TITLE
Omit ALTER lines when there are no proposed fixes

### DIFF
--- a/bash-script/BlueGreen-precheck-v1.8.sh
+++ b/bash-script/BlueGreen-precheck-v1.8.sh
@@ -189,11 +189,13 @@ function check_all_databases() {
       GROUP BY n.nspname, c.relname, c.relreplident, indisprimary;
     "
 
-    proposed_fixes=$(exec_query "$fix_tables_query")
+    proposed_fixes=$(exec_query "$fix_tables_query" | sed -n "/;$/p")
     if [[ -n $proposed_fixes ]]; then
       printf "\nProposed commands to fix tables in %s:\n" "$db"
       printf "%s\n" "$proposed_fixes"
       issues_found=1
+    else
+      printf "The tables in the database do not need to be altered\n"
     fi
 
     # Check for presence of pg_largeobject


### PR DESCRIPTION
When no tables have a need for ALTER statements from the `fix_table_query`, the script output contains a line for each table checked. The output looks like this:

```
Proposed commands to fix tables in accounting:
 ALTER TABLE public.invoices
 ALTER TABLE public.invoice_line_items
 ALTER TABLE public.ar_internal_metadata
 ALTER TABLE public.schema_migrations
```

This PR changes that. Any proposed fix returned from the query that does not end with a semicolon is removed. If there are no proposed fixes after the filtering the output tells you no tables need to be altered.

```
The tables in the database do not need to be altered
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.