### PR TITLE
Correct REPLICA IDENTITY FULL syntax

### DIFF
--- a/bash-script/BlueGreen-precheck-v1.8.sh
+++ b/bash-script/BlueGreen-precheck-v1.8.sh
@@ -170,9 +170,9 @@ function check_all_databases() {
           WHEN indisprimary IS NULL AND c.relreplident != 'f' THEN
             ' ADD PRIMARY KEY (' || string_agg(a.attname, ', ') || ');'
           WHEN indisprimary IS NULL AND c.relreplident = 'f' THEN
-            ' SET REPLICA IDENTITY FULL; ADD PRIMARY KEY (' || string_agg(a.attname, ', ') || ');'
+            ' REPLICA IDENTITY FULL; ADD PRIMARY KEY (' || string_agg(a.attname, ', ') || ');'
           WHEN c.relreplident != 'f' THEN
-            ' SET REPLICA IDENTITY FULL;'
+            ' REPLICA IDENTITY FULL;'
           ELSE
             ''
         END AS proposed_fix


### PR DESCRIPTION
The ALTER TABLE command for enabling REPLICA IDENTITY FULL should not include "SET" because it's invalid syntax. This corrects the generated SQL commands.

See https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
